### PR TITLE
Fix Desktop target

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/mmartosdev/lottieviewer/ui/Home.kt
+++ b/composeApp/src/commonMain/kotlin/com/mmartosdev/lottieviewer/ui/Home.kt
@@ -216,8 +216,8 @@ fun HomeScreenLottiePlayer(
             modifier = modifier
                 .padding(16.dp),
         ) {
-            val animatable = rememberLottieAnimatable()
-            LaunchedEffect(isPlaying) {
+            val animatable = remember(composition) { LottieAnimatable() }
+            LaunchedEffect(animatable, isPlaying) {
                 if (isPlaying) {
                     animatable.animate(
                         composition = composition,

--- a/composeApp/src/jvmMain/kotlin/com/mmartosdev/lottieviewer/utils/onDragAndDrop.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/mmartosdev/lottieviewer/utils/onDragAndDrop.jvm.kt
@@ -1,10 +1,15 @@
 package com.mmartosdev.lottieviewer.utils
 
+import androidx.compose.foundation.draganddrop.dragAndDropTarget
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.DragData
+import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.onExternalDrag
+import androidx.compose.ui.composed
+import androidx.compose.ui.draganddrop.DragAndDropEvent
+import androidx.compose.ui.draganddrop.DragAndDropTarget
+import androidx.compose.ui.draganddrop.DragData
+import androidx.compose.ui.draganddrop.dragData
 import com.mmartosdev.lottieviewer.data.FileDesc
 import java.net.URI
 
@@ -16,13 +21,29 @@ actual fun Modifier.onDragAndDrop(
     onDragStart: () -> Unit,
     onDragExit: () -> Unit,
     onSingleFileDropped: (FileDesc) -> Unit,
-): Modifier = this then onExternalDrag(
-    enabled = true,
-    onDrag = { },
-    onDrop = { extractSingleFile(it.dragData)?.run { onSingleFileDropped(this) } },
-    onDragExit = { onDragExit() },
-    onDragStart = { onDragStart() },
-)
+): Modifier = composed {
+    val target = remember {
+        object : DragAndDropTarget {
+            override fun onEntered(event: DragAndDropEvent) {
+                onDragStart()
+            }
+
+            override fun onExited(event: DragAndDropEvent) {
+                onDragExit()
+            }
+
+            override fun onDrop(event: DragAndDropEvent): Boolean =
+                extractSingleFile(event.dragData())?.run {
+                    onSingleFileDropped(this)
+                    true
+                } ?: false
+        }
+    }
+    dragAndDropTarget(
+        shouldStartDragAndDrop = { true },
+        target = target,
+    )
+}
 
 @OptIn(ExperimentalComposeUiApi::class)
 private fun extractSingleFile(dragData: DragData): FileDesc? =


### PR DESCRIPTION
Fix compile time issue related to Desktop target.
Also avoid reusing Lottie Composition between different dropped files avoiding an issue where duration of previous lottie file affects new one.